### PR TITLE
Clear output in notebook.

### DIFF
--- a/index.ipynb
+++ b/index.ipynb
@@ -17,21 +17,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "ModuleNotFoundError",
-     "evalue": "No module named 'bqplot'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mModuleNotFoundError\u001b[0m                       Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-1-da17ddc8b63b>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      3\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      4\u001b[0m \u001b[0;32mfrom\u001b[0m \u001b[0mipywidgets\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mFloatSlider\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mHBox\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mVBox\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 5\u001b[0;31m \u001b[0;32mimport\u001b[0m \u001b[0mbqplot\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mpyplot\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0mplt\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[0;31mModuleNotFoundError\u001b[0m: No module named 'bqplot'"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import numpy as np\n",
     "from scipy.stats import norm\n",
@@ -71,9 +59,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def update_density(change):\n",
@@ -102,15 +88,6 @@
     "final_layout = VBox([pdf_fig, slider_layout])\n",
     "final_layout"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -129,7 +106,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 bqplot==0.11.5
 scipy==1.1.0
-voila==0.1.6
+voila==0.1.10


### PR DESCRIPTION
Hello @jtpio!

This changeset does *not* change anything functionality-wise, since `voila` runs the code cells by itself (for its own purposes, so to speak).

But it's nicer to land on a static (rendered) notebook free of errors when visiting https://github.com/voila-gallery/gaussian-density/blob/master/index.ipynb (e.g., as linked from the deployed app at "Find the code ..."). Alternatively, we could actually run the cells and keep their outputs for displaying purposes. Again, this doesn't change anything with `voila`...

I updated the version of `voila` because it didn't hurt.

Cheers,
Marianne